### PR TITLE
Feature/18 workflow version info

### DIFF
--- a/.github/workflows/pnpm.yaml
+++ b/.github/workflows/pnpm.yaml
@@ -37,6 +37,10 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+      - name: update src/App/version.txt
+        run: |
+          git config core.quotepath false
+          git show --name-status HEAD > src/App/version.txt
       - name: pnpm install
         run: pnpm install
       - name: pnpm run check

--- a/src/App/App.svelte
+++ b/src/App/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Counter from "../lib/Counter";
   import TodoList from "../lib/TodoList";
+  import version from "./version.txt?raw";
 </script>
 
 <hr class="m-2 max-w-200 text-slate-300" />
@@ -13,3 +14,7 @@
 <hr class="m-2 max-w-200 text-slate-300" />
 
 <button class="btn btn-info">This button does nothing</button>
+
+<div role="alert" class="alert alert-info m-4">
+  <pre>{version}</pre>
+</div>

--- a/src/App/version.txt
+++ b/src/App/version.txt
@@ -1,0 +1,1 @@
+Unknown version


### PR DESCRIPTION
Done:

- **src/App/version.txt** created and dumped to browser by **App** (raw content)
- **pnpm.yaml** workflow updates it using `git show --name-status HEAD` output
- It hasn't been run but it should work OK since it's a simple change
  - It's easily fixable otherwise